### PR TITLE
Add complete example and fix lambda permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ crash.log
 
 # Taskfile
 .task/
+
+# Generated config
+examples/complete/generated-config.yml

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,0 +1,3 @@
+## examples/complete
+
+An example which shows a more _complete_ usage of the module.

--- a/examples/complete/config.yml
+++ b/examples/complete/config.yml
@@ -1,0 +1,4 @@
+- type: random
+  name: random-string-3
+  config:
+    length: 20

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,0 +1,121 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+provider "aws" {
+  version = ">= 2.61"
+  region  = var.region
+}
+
+resource "local_file" "config" {
+  filename = "${path.module}/generated-config.yml"
+  content  = <<EOF
+- type: aws:sts
+  name: sts-credential-1
+  config:
+    role_arn: ${aws_iam_role.example.arn}
+    duration: 900
+EOF
+}
+
+module "sidecred" {
+  source      = "../../"
+  name_prefix = var.name_prefix
+
+  configurations = [
+    {
+      namespace = "example"
+      config    = "config.yml"
+    },
+    {
+      namespace = "example"
+      config    = local_file.config.filename
+    }
+  ]
+
+  environment = {
+    SIDECRED_RANDOM_PROVIDER_ROTATION_INTERVAL = "20m"
+    SIDECRED_STS_PROVIDER_ENABLED              = "true"
+    SIDECRED_STS_PROVIDER_SESSION_DURATION     = "20m"
+    SIDECRED_SECRET_STORE_BACKEND              = "ssm"
+    SIDECRED_SSM_STORE_PATH_TEMPLATE           = "/sidecred/{{ .Namespace }}/{{ .Name }}"
+    SIDECRED_DEBUG                             = "true"
+    SIDECRED_ROTATION_WINDOW                   = "19m"
+  }
+
+  tags = {
+    terraform   = "true"
+    environment = "dev"
+  }
+}
+
+resource "aws_iam_role_policy" "sidecred" {
+  name   = "sidecred-permissions"
+  role   = module.sidecred.role_name
+  policy = data.aws_iam_policy_document.sidecred.json
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "sidecred" {
+  # Allow STS provider to assume any role (in any account) with a sidecred = allow tag.
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    resources = [
+      "arn:aws:iam::*:role/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:ResourceTag/sidecred"
+      values   = ["allow"]
+    }
+  }
+
+  # Read/write SSM Parameters (required for the secret store)
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ssm:PutParameter",
+      "ssm:DeleteParameter",
+    ]
+
+    resources = [
+      "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/sidecred*",
+    ]
+  }
+}
+
+# Example of an assumable IAM role that can be used in a STS provider request.
+resource "aws_iam_role" "example" {
+  name               = "${var.name_prefix}-assumable-role"
+  assume_role_policy = data.aws_iam_policy_document.example_assume.json
+
+  tags = {
+    sidecred    = "allow"
+    terraform   = "true"
+    environment = "dev"
+  }
+}
+
+data "aws_iam_policy_document" "example_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        # For cross account roles this should be the ARN of the sidecred execution role.
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+      ]
+    }
+  }
+}

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,0 +1,4 @@
+output "arn" {
+  description = "The Amazon Resource Name (ARN) identifying the sidecred Lambda Function."
+  value       = module.sidecred.arn
+}

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,0 +1,9 @@
+variable "name_prefix" {
+  type    = string
+  default = "sidecred-complete-example"
+}
+
+variable "region" {
+  type    = string
+  default = "eu-west-1"
+}

--- a/main.tf
+++ b/main.tf
@@ -86,8 +86,8 @@ data "aws_iam_policy_document" "lambda" {
 
 resource "aws_cloudwatch_event_rule" "main" {
   count               = length(local.configs)
-  name                = "${local.configs[count.index].namespace}-sidecred-trigger"
-  description         = "${local.configs[count.index].namespace} sidecred trigger."
+  name_prefix         = "sidecred-${local.configs[count.index].namespace}"
+  description         = "Trigger for ${local.configs[count.index].config_path}."
   schedule_expression = "rate(10 minutes)"
   tags                = var.tags
 }
@@ -101,7 +101,7 @@ resource "aws_cloudwatch_event_target" "main" {
 
 resource "aws_lambda_permission" "main" {
   count         = length(local.configs)
-  statement_id  = "${local.configs[count.index].namespace}-sidecred-permission"
+  statement_id  = aws_cloudwatch_event_rule.main[count.index].id
   function_name = module.lambda.arn
   action        = "lambda:InvokeFunction"
   principal     = "events.amazonaws.com"

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,8 +7,13 @@ output "arn" {
 }
 
 output "role_arn" {
-  description = "The Amazon Resource Name (ARN) specifying the sidecred lambda execution role."
+  description = "The ARN of the sidecred lambda execution role."
   value       = module.lambda.role_arn
+}
+
+output "role_name" {
+  description = "The name of the sidecred lambda execution role."
+  value       = module.lambda.role_name
 }
 
 output "bucket_id" {

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -13,20 +13,39 @@ import (
 
 func TestModule(t *testing.T) {
 	tests := []struct {
-		description string
-		directory   string
-		name        string
-		region      string
-		expected    module.Expectations
+		description     string
+		directory       string
+		name            string
+		region          string
+		events          []string
+		expected        module.Expectations
+		generatesConfig bool
 	}{
 		{
 			description: "basic example",
 			directory:   "../examples/basic",
 			name:        fmt.Sprintf("sidecred-basic-test-%s", random.UniqueId()),
 			region:      "eu-west-1",
+			events: []string{
+				`{"namespace":"example","config_path":"example/config.yml","state_path":"example/config.yml.state"}`,
+			},
 			expected: module.Expectations{
 				Parameters: []string{"/sidecred/example/random-string-1", "/sidecred/example/random-string-2"},
 			},
+		},
+		{
+			description: "complete example",
+			directory:   "../examples/complete",
+			name:        fmt.Sprintf("sidecred-complete-test-%s", random.UniqueId()),
+			region:      "eu-west-1",
+			events: []string{
+				`{"namespace":"example","config_path":"example/config.yml","state_path":"example/config.yml.state"}`,
+				`{"namespace":"example","config_path":"example/generated-config.yml","state_path":"example/generated-config.yml.state"}`,
+			},
+			expected: module.Expectations{
+				Parameters: []string{"/sidecred/example/random-string-3", "/sidecred/example/sts-credential-1-access-key"},
+			},
+			generatesConfig: true,
 		},
 	}
 
@@ -37,23 +56,30 @@ func TestModule(t *testing.T) {
 
 			options := &terraform.Options{
 				TerraformDir: tc.directory,
-
 				Vars: map[string]interface{}{
 					// Bucket name needs to be lowercase.
 					"name_prefix": strings.ToLower(tc.name),
 					"region":      tc.region,
 				},
-
 				EnvVars: map[string]string{
 					"AWS_DEFAULT_REGION": tc.region,
 				},
 			}
 
 			defer terraform.Destroy(t, options)
+
+			// Terraform does not include the local file in the dependency graph.
+			// Hence we need to apply with a target to generate the config first.
+			if tc.generatesConfig {
+				options.Targets = []string{"local_file.config"}
+				terraform.InitAndApply(t, options)
+				options.Targets = nil
+			}
+
 			terraform.InitAndApply(t, options)
 
 			lambdaARN := terraform.Output(t, options, "arn")
-			module.RunTestSuite(t, lambdaARN, tc.region, tc.expected)
+			module.RunTestSuite(t, lambdaARN, tc.events, tc.region, tc.expected)
 		})
 	}
 }


### PR DESCRIPTION
This PR moves all permissions related to sidecred outside the module. We can consider moving it back if we find a good way of conditionally adding statements, but for now its just easier to leave it up to the user to add permissions depending on how they want to configure sidecred.

I've also added a "complete" example that includes an STS policy statement and sends a request for `aws:sts` credentials/validates that they are successfully populated.