### PR TITLE
Update default version of sidecred

### DIFF
--- a/examples/basic/config.yml
+++ b/examples/basic/config.yml
@@ -1,8 +1,19 @@
-- type: random
-  name: random-string-1
-  config:
-    length: 20
-- type: random
-  name: random-string-2
-  config:
-    length: 15
+---
+version: 1
+
+namespace: example
+
+stores:
+  - type: ssm
+
+requests:
+  - store: ssm 
+    creds:
+    - type: random
+      name: random-string-1
+      config:
+        length: 20
+    - type: random
+      name: random-string-2
+      config:
+        length: 15

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -18,8 +18,8 @@ module "sidecred" {
 
   environment = {
     SIDECRED_RANDOM_PROVIDER_ROTATION_INTERVAL = "1m"
-    SIDECRED_SECRET_STORE_BACKEND              = "ssm"
-    SIDECRED_SSM_STORE_PATH_TEMPLATE           = "/sidecred/{{ .Namespace }}/{{ .Name }}"
+    SIDECRED_SSM_STORE_ENABLED                 = "true"
+    SIDECRED_SSM_STORE_SECRET_TEMPLATE         = "/sidecred/{{ .Namespace }}/{{ .Name }}"
     SIDECRED_DEBUG                             = "true"
   }
 

--- a/examples/complete/config.yml
+++ b/examples/complete/config.yml
@@ -1,4 +1,15 @@
-- type: random
-  name: random-string-3
-  config:
-    length: 20
+---
+version: 1
+
+namespace: example
+
+stores:
+  - type: ssm
+
+requests:
+  - store: ssm 
+    creds:
+    - type: random
+      name: random-string-3
+      config:
+        length: 20

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,11 +10,22 @@ provider "aws" {
 resource "local_file" "config" {
   filename = "${path.module}/generated-config.yml"
   content  = <<EOF
-- type: aws:sts
-  name: sts-credential-1
-  config:
-    role_arn: ${aws_iam_role.example.arn}
-    duration: 900
+---
+version: 1
+
+namespace: example
+
+stores:
+  - type: ssm
+
+requests:
+  - store: ssm 
+    creds:
+    - type: aws:sts
+      name: sts-credential-1
+      config:
+        role_arn: ${aws_iam_role.example.arn}
+        duration: 900
 EOF
 }
 
@@ -37,8 +48,8 @@ module "sidecred" {
     SIDECRED_RANDOM_PROVIDER_ROTATION_INTERVAL = "20m"
     SIDECRED_STS_PROVIDER_ENABLED              = "true"
     SIDECRED_STS_PROVIDER_SESSION_DURATION     = "20m"
-    SIDECRED_SECRET_STORE_BACKEND              = "ssm"
-    SIDECRED_SSM_STORE_PATH_TEMPLATE           = "/sidecred/{{ .Namespace }}/{{ .Name }}"
+    SIDECRED_SSM_STORE_ENABLED                 = "true"
+    SIDECRED_SSM_STORE_SECRET_TEMPLATE         = "/sidecred/{{ .Namespace }}/{{ .Name }}"
     SIDECRED_DEBUG                             = "true"
     SIDECRED_ROTATION_WINDOW                   = "19m"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "s3_bucket" {
 variable "s3_key" {
   description = "The s3 key for the Lambda artifact."
   type        = string
-  default     = "sidecred-lambda/v0.5.0.zip"
+  default     = "sidecred-lambda/v0.7.0.zip"
 }
 
 variable "filename" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,8 @@
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    # 3.0 makes aws_s3_bucket.region read-only which is a breaking change for this module.
+    aws = "~> 2.0"
+  }
 }


### PR DESCRIPTION
This PR updates the default version of Sidecred used in this module to `v0.7.0`. I'll make a new release once this is merged.