### PR TITLE
Expose lambda schedule expression

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_cloudwatch_event_rule" "main" {
   count               = length(local.configs)
   name_prefix         = "sidecred-${local.configs[count.index].namespace}"
   description         = "Trigger for ${local.configs[count.index].config_path}."
-  schedule_expression = "rate(10 minutes)"
+  schedule_expression = var.schedule_expression
   tags                = var.tags
 }
 
@@ -107,4 +107,3 @@ resource "aws_lambda_permission" "main" {
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.main[count.index].arn
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "environment" {
   type        = map(string)
 }
 
+variable "schedule_expression" {
+  description = "The scheduling expression for how often sidecred should run. For example, cron(0 */5 * ? * *) or rate(10 minutes)."
+  type        = string
+  default     = "rate(10 minutes)"
+}
+
 variable "s3_bucket" {
   description = "The bucket where the lambda function is uploaded."
   type        = string


### PR DESCRIPTION
This resolved #6 by exposing the rate expression for the CloudWatch Event Rule, and defaults to the previous hardcoded one (10 minutes).