### PR TITLE
updated for latest sidecred version of 0.13.0

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "s3_bucket" {
 variable "s3_key" {
   description = "The s3 key for the lambda artifact."
   type        = string
-  default     = "sidecred-lambda/v0.12.0.zip"
+  default     = "sidecred-lambda/v0.13.0.zip"
 }
 
 variable "filename" {


### PR DESCRIPTION
as title suggests, updated variables.tf file to use the latest version of sidecred (0.13.0).

Sidecred version update:
Add Sidecred credentials to GH Action by @rickardl in https://github.com/telia-oss/sidecred/pull/75
Add support for token naming in configuration file by @ian1780 in https://github.com/telia-oss/sidecred/pull/77