### PR TITLE
Add support for v4 of the AWS provider

### DIFF
--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/main.tf
+++ b/main.tf
@@ -21,10 +21,6 @@ resource "aws_s3_bucket" "bucket" {
   bucket        = "${data.aws_caller_identity.current.account_id}-${var.name_prefix}"
   force_destroy = true
   tags          = var.tags
-
-  lifecycle {
-    ignore_changes = [acl, versioning]
-  }
 }
 
 resource "aws_s3_bucket_acl" "bucket" {

--- a/main.tf
+++ b/main.tf
@@ -19,14 +19,25 @@ locals {
 
 resource "aws_s3_bucket" "bucket" {
   bucket        = "${data.aws_caller_identity.current.account_id}-${var.name_prefix}"
-  acl           = "private"
   force_destroy = true
+  tags          = var.tags
 
-  versioning {
-    enabled = true
+  lifecycle {
+    ignore_changes = [acl, versioning]
   }
+}
 
-  tags = var.tags
+resource "aws_s3_bucket_acl" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 data "local_file" "config" {
@@ -44,7 +55,7 @@ resource "aws_s3_bucket_object" "configurations" {
 
 module "lambda" {
   source  = "telia-oss/lambda/aws"
-  version = "4.1.1"
+  version = "4.2.0"
 
   name_prefix      = var.name_prefix
   filename         = var.filename

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = ">= 3.75, < 5.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
     }
   }
 }


### PR DESCRIPTION
As per title, this PR relaxes the provider constraint and adds support for the v4 provider. I have removed the `acl` and `versioning {}` from the `aws_s3_bucket` and use the new resources that were [introduced in `3.75.0`](https://github.com/hashicorp/terraform-provider-aws/blob/release/3.x/CHANGELOG.md#3750-march-18-2022) of the provider.

~Also added a `lifecycle { ignore_changes }` which ensures that we don't get a conflict/race condition when upgrading the provider from v3 to v4, which can be used as a "stepping stone release". Next release could remove it.~ Edit: this seems to not be necessary.